### PR TITLE
Fix EmailJS v4 API: wrap public key in options object

### DIFF
--- a/script.js
+++ b/script.js
@@ -241,7 +241,7 @@ async function sendEmailNotification(requestData, status, reason = "") {
       state.config.emailjsServiceId,
       state.config.emailjsTemplateId,
       templateParams,
-      state.config.emailjsPublicKey
+      { publicKey: state.config.emailjsPublicKey }
     );
     console.log("Email sent successfully!");
   } catch (error) {


### PR DESCRIPTION
EmailJS v4 changed the 4th parameter of emailjs.send() from a plain
string (v3 user ID) to an options object {publicKey: string}.

https://claude.ai/code/session_01QLaHhjnjrNzJgnvLoUiFYm